### PR TITLE
Update hapi peerDependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.4.1"
   },
   "peerDependencies": {
-    "hapi": "13.x"
+    "hapi": "14.x"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
I understood that kookaburra works with hapi 14.x without any changes.
